### PR TITLE
Update supported Pythons, 100% coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+source = zope.sequencesort
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    raise AssertionError

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs/_build
 bin
 develop-eggs
 eggs
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,24 @@
 language: python
+sudo: false
 python:
-    - 2.6
     - 2.7
-    - 3.2
-    - 3.3
+    - 3.4
+    - 3.5
+    - 3.6
     - pypy
+matrix:
+    include:
+        - python: "3.7"
+          dist: xenial
+          sudo: true
 install:
-    - pip install .
+  - pip install -U pip setuptools wheel
+  - pip install -U coverage coveralls
+  - pip install -U -e .[test]
 script:
-    - python setup.py test -q
+  - coverage run -m zope.testrunner --test-path=src
+after_success:
+  - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@
 
 - Add support for Python 3.4, 3.5, 3.6 and 3.7.
 
+- The locale comparison functions, ``strcoll`` and ``strcoll_nocase``
+  are always available, not only if the ``locale`` module had been
+  imported before this module.
+
 4.0.1 (2013-03-04)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,18 +1,23 @@
-``zope.sequencesort`` Changelog
-===============================
+===========
+ Changelog
+===========
 
-4.0.2 (unreleased)
-------------------
+4.1.0 (unreleased)
+==================
 
 - Updated ``boostrap.py`` to version 2.2.
 
+- Drop support for Python 2.6, 3.2 and 3.3.
+
+- Add support for Python 3.4, 3.5, 3.6 and 3.7.
+
 4.0.1 (2013-03-04)
-------------------
+==================
 
 - Fix omitted tests under Py3k.
 
 4.0.0 (2013-02-28)
-------------------
+==================
 
 - Added ``setup.py docs`` alias (installs ``Sphinx`` and dependencies).
 
@@ -28,6 +33,6 @@
 - Dropped support for Python 2.4 / 2.5.
 
 3.4.0 (2007-10-03)
-------------------
+==================
 
 - Initial release independent of the main Zope3 tree.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,10 @@
 include *.py
 include *.txt
+include *.rst
 include buildout.cfg
 include tox.ini
+include .travis.yml
+include .coveragerc
 recursive-include docs *.bat
 recursive-include docs *.py
 recursive-include docs *.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,8 +5,11 @@ include buildout.cfg
 include tox.ini
 include .travis.yml
 include .coveragerc
+
 recursive-include docs *.bat
 recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs *.txt
 recursive-include docs Makefile
+
+prune docs/_build

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,22 @@
+===================
+ zope.sequencesort
+===================
+
+.. image:: https://img.shields.io/pypi/v/zope.sequencesort.svg
+   :target: https://pypi.org/project/zope.sequencesort/
+   :alt: Latest Version
+
+.. image:: https://travis-ci.org/zopefoundation/zope.sequencesort.svg?branch=master
+   :target: https://travis-ci.org/zopefoundation/zope.sequencesort
+
+.. image:: https://readthedocs.org/projects/zopesequencesort/badge/?version=latest
+   :target: https://zopesequencesort.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
+
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.sequencesort/badge.svg
+   :target: https://coveralls.io/github/zopefoundation/zope.sequencesort
+
+
+
+This package provides support for sorting sequences based on multiple
+keys, including locale-based comparisons and per-key directions.

--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,0 @@
-``zope.sequencesort`` README
-============================
-
-This package provides support for sorting sequences based on multiple
-keys, including locale-based comparisons and per-key directions.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,5 @@
 .. zope.sequencesort documentation master file, created by
+
 :mod:`zope.sequencesort`
 ========================
 
@@ -16,4 +17,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,6 @@ where=src
 [aliases]
 dev = develop easy_install zope.sequencesort[testing]
 docs = easy_install zope.sequencesort[docs]
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         ],
     },
     install_requires=[
-        'setuptools'
+        'setuptools',
     ],
     include_package_data=True,
     zip_safe=False

--- a/setup.py
+++ b/setup.py
@@ -22,47 +22,58 @@ import os
 from setuptools import setup, find_packages
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
+        return f.read()
 
-setup(name="zope.sequencesort",
-      version = '4.0.2dev',
-      author='Zope Foundation and Contributors',
-      author_email='zope-dev@zope.org',
-      description='Sequence Sorting',
-      long_description=(
-          read('README.txt')
-          + '\n\n' +
-          read('CHANGES.txt')
-          ),
-      keywords = "zope3 sequence sort",
-      classifiers = [
-          'Development Status :: 5 - Production/Stable',
-          'Environment :: Web Environment',
-          'Intended Audience :: Developers',
-          'License :: OSI Approved :: Zope Public License',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 2.6',
-          'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.2',
-          'Programming Language :: Python :: 3.3',
-          "Programming Language :: Python :: Implementation :: CPython",
-          "Programming Language :: Python :: Implementation :: PyPy",
-          'Natural Language :: English',
-          'Operating System :: OS Independent',
-          'Topic :: Internet :: WWW/HTTP',
-          'Framework :: Zope3'],
-      url='http://cheeseshop.python.org/pypi/zope.sequencesort',
-      license='ZPL 2.1',
-      packages=find_packages('src'),
-      package_dir = {'': 'src'},
-      namespace_packages=['zope'],
-      test_suite='zope.sequencesort',
-      extras_require={'docs': ['Sphinx'],
-                      'testing': ['nose', 'coverage'],
-                     },
-      install_requires = ['setuptools'],
-      include_package_data=True,
-      zip_safe = False
-      )
+setup(
+    name="zope.sequencesort",
+    version='4.1.0.dev0',
+    author='Zope Foundation and Contributors',
+    author_email='zope-dev@zope.org',
+    description='Sequence Sorting',
+    long_description=(
+        read('README.rst')
+        + '\n\n' +
+        read('CHANGES.rst')
+    ),
+    keywords="zope3 sequence sort",
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Web Environment',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Zope Public License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Topic :: Internet :: WWW/HTTP',
+        'Framework :: Zope3',
+    ],
+    url='https://github.com/zopefoundation/zope.sequencesort',
+    license='ZPL 2.1',
+    packages=find_packages('src'),
+    package_dir={'': 'src'},
+    namespace_packages=['zope'],
+    test_suite='zope.sequencesort',
+    extras_require={
+        'docs': [
+            'Sphinx',
+        ],
+        'test': [
+            'zope.testrunner',
+        ],
+    },
+    install_requires=[
+        'setuptools'
+    ],
+    include_package_data=True,
+    zip_safe=False
+)

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,30 @@
 [tox]
-envlist = 
-#    py26,py27,pypy,coverage,docs
-    py26,py27,pypy,,py32,py33,coverage
+envlist =
+    py27,pypy,py34,py35,py36,py37,coverage
 
 [testenv]
-commands = 
-    python setup.py test -q
+commands =
+    zope-testrunner --test-path=src
+deps =
+     .[test]
 
 [testenv:coverage]
+usedevelop = true
 basepython =
-    python2.6
-commands = 
-    nosetests --with-xunit --with-xcoverage
+    python3.6
+commands =
+    coverage run -m zope.testrunner --test-path=src
+    coverage report
 deps =
-    nose
+    {[testenv]:deps}
     coverage
-    nosexcover
+
 
 [testenv:docs]
 basepython =
-    python2.6
-commands = 
+    python3.6
+commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 deps =
-    Sphinx
+    .[docs]

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,9 @@ basepython =
     python3.6
 commands =
     coverage run -m zope.testrunner --test-path=src
-    coverage report
+    coverage report --fail-under=100
 deps =
-    {[testenv]:deps}
+    {[testenv]deps}
     coverage
 
 


### PR DESCRIPTION
Make the locale comparison functions always available, not just if that module had previously been imported before this module. That was a big footgun IMO.

Fixes #1. 