### PR TITLE
Handle sorting of broken objects more gracefully.

### DIFF
--- a/src/zope/sequencesort/ssort.py
+++ b/src/zope/sequencesort/ssort.py
@@ -256,6 +256,10 @@ class SortBy(object):
             # if not multsort - i is 0, and the 0th element is the key
             c1, c2 = o1[i], o2[i]
             func, multiplier = self.sf_list[i][1:3]
+            if c1 is _Smallest:
+                return -1
+            elif c2 is _Smallest:
+                return 1
             n = func(c1, c2)
             if n:
                 return n * multiplier

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ basepython =
     python3.6
 commands =
     coverage run -m zope.testrunner --test-path=src
-    coverage report --fail-under=100
+    coverage report --show-missing --fail-under=100
 deps =
     {[testenv]deps}
     coverage


### PR DESCRIPTION
Repaired handling of broken objects (that can be compared but do not offer the required keys and can not be used in string functions like .lower() and strcoll()), which is used in the new ZMI.
Fixes: #3 