### PR TITLE
Make `_Smallest` objects equal again.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 4.2 (unreleased)
 ================
 
-- Nothing changed yet.
+- Fix regression introduced in 4.1.1 where to `_Smallest` objects are no longer
+  equal.
 
 
 4.1.1 (2018-10-05)

--- a/src/zope/sequencesort/ssort.py
+++ b/src/zope/sequencesort/ssort.py
@@ -242,7 +242,6 @@ class SortBy(object):
         else:
             req_len = n_fields + 1
 
-
         # assert that o1 and o2 are tuples of apropriate length
         if len(o1) != req_len:
             raise ValueError("%s, %d" % (o1, req_len))
@@ -256,6 +255,8 @@ class SortBy(object):
             # if not multsort - i is 0, and the 0th element is the key
             c1, c2 = o1[i], o2[i]
             func, multiplier = self.sf_list[i][1:3]
+            if c1 is _Smallest and c2 is _Smallest:
+                return 0
             if c1 is _Smallest:
                 return -1
             elif c2 is _Smallest:

--- a/src/zope/sequencesort/tests/test_ssort.py
+++ b/src/zope/sequencesort/tests/test_ssort.py
@@ -340,6 +340,12 @@ class SortByTests(unittest.TestCase):
         self.assertEqual(sb((['a', 'q'], None), (['a', 'r'], None)), 1)
         self.assertEqual(sb((['b', 'p'], None), (['a', 'q'], None)), 1)
 
+    def test_smallest(self):
+        from zope.sequencesort.ssort import _Smallest
+        sb = self._makeOne(False, [self._makeField('bar')])
+        self.assertEqual(sb(('a', None), (_Smallest, None)), 1)
+        self.assertEqual(sb((_Smallest, None), ('a', None)), -1)
+        self.assertEqual(sb((_Smallest, None), (_Smallest, None)), 0)
 
 WORDLIST = [
     {"key": "aaa", "word": "AAA", "weight": 1},


### PR DESCRIPTION
This is a regression introduced in 4.1.1 breaking tests in Zope
(e. g. [OFS.tests.testOrderSupport.TestOrderSupport.test_orderObjects](https://github.com/zopefoundation/Zope/blob/478319637795508082823eeabe907e34322b1fe2/src/OFS/tests/testOrderSupport.py#L124-L131))